### PR TITLE
Distance edge

### DIFF
--- a/yaramo/edge.py
+++ b/yaramo/edge.py
@@ -53,5 +53,5 @@ class Edge(BaseElement):
         for signal in self.signals:
             if signal.function in [SignalFunction.Einfahr_Signal, SignalFunction.Ausfahr_Signal, SignalFunction.Block_Signal] and signal.direction == direction:
                 result.append(signal)
-        result.sort(key=lambda x: x.distance_previous_node, reverse=(direction == SignalDirection.GEGEN))
+        result.sort(key=lambda x: x.distance_edge, reverse=(direction == SignalDirection.GEGEN))
         return result

--- a/yaramo/model.py
+++ b/yaramo/model.py
@@ -1,4 +1,4 @@
-from yaramo.signal import Signal, SignalDirection, SignalFunction
+from yaramo.signal import Signal, SignalDirection, SignalFunction, SignalKind
 from yaramo.additional_signal import AdditionalSignalZs1, AdditionalSignalZs2, AdditionalSignalZs3
 from yaramo.node import Node
 from yaramo.geo_node import Wgs84GeoNode, DbrefGeoNode

--- a/yaramo/route.py
+++ b/yaramo/route.py
@@ -67,19 +67,19 @@ class Route(BaseElement):
 
             if i == 0:
                 if self.start_signal.direction == SignalDirection.IN:
-                    from_d = self.start_signal.distance_previous_node
+                    from_d = self.start_signal.distance_edge
                     to_d = edge.length
                 else:
-                    from_d = self.start_signal.distance_previous_node
+                    from_d = self.start_signal.distance_edge
                     to_d = 0.0
                 output_dict["edges"].append({"edge_uuid": edge.uuid, "from": float(from_d), "to": float(to_d)})
             elif i == len(self.edges) - 1:
                 if self.end_signal.direction == SignalDirection.IN:
                     from_d = 0.0
-                    to_d = self.end_signal.distance_previous_node
+                    to_d = self.end_signal.distance_edge
                 else:
                     from_d = edge.length
-                    to_d = self.end_signal.distance_previous_node
+                    to_d = self.end_signal.distance_edge
                 output_dict["edges"].append({"edge_uuid": edge.uuid, "from": float(from_d), "to": float(to_d)})
                 pass
             else:

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -42,17 +42,20 @@ class Signal(BaseElement):
         super().__init__(**kwargs)
         self.trip: Trip = None
         self.edge = edge
-        self.direction = SignalDirection.IN if direction == SignalDirection.IN or direction.lower() == SignalDirection.IN.name.lower() else SignalDirection.GEGEN
-        
-        if side_distance is not None:
-            self.side_distance = side_distance if self.direction == SignalDirection.IN else -side_distance
-        else:
-            self.side_distance = 3.950 if self.direction == SignalDirection.IN else -3.950
-
         self.distance_edge = distance_edge
         self.classification_number = "60"
         self.control_member_uuid = str(uuid4())
         self.additional_signals = list[AdditionalSignal]
+        
+        if isinstance(direction, str):
+            self.direction = SignalDirection.__members__.get(direction, SignalDirection.IN)
+        elif isinstance(direction, SignalDirection):
+            self.direction = direction
+
+        if side_distance is not None:
+            self.side_distance = side_distance if self.direction == SignalDirection.IN else -side_distance
+        else:
+            self.side_distance = 3.950 if self.direction == SignalDirection.IN else -3.950
         
         if isinstance(function, str):
             self.function = SignalFunction.__members__.get(function, SignalFunction.andere)

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -38,7 +38,7 @@ class SignalKind(Enum):
 
 class Signal(BaseElement):
 
-    def __init__(self, edge: Edge, distance_previous_node: float, direction: SignalDirection | str, function: SignalFunction | str, kind: SignalKind | str, side_distance: float = None,  **kwargs):
+    def __init__(self, edge: Edge, distance_edge: float, direction: SignalDirection | str, function: SignalFunction | str, kind: SignalKind | str, side_distance: float = None,  **kwargs):
         super().__init__(**kwargs)
         self.trip: Trip = None
         self.edge = edge
@@ -49,7 +49,7 @@ class Signal(BaseElement):
         else:
             self.side_distance = 3.950 if self.direction == SignalDirection.IN else -3.950
 
-        self.distance_previous_node = distance_previous_node
+        self.distance_edge = distance_edge
         self.classification_number = "60"
         self.control_member_uuid = str(uuid4())
         self.additional_signals = list[AdditionalSignal]
@@ -69,3 +69,10 @@ class Signal(BaseElement):
 
     def next_node(self):
         return self.edge.node_b if self.direction == SignalDirection.IN else self.edge.node_a
+    
+    @property
+    def distance_previous_node(self):
+        if self.direction == SignalDirection.IN:
+            return self.distance_edge
+        else:
+            return self.edge.length - self.distance_edge


### PR DESCRIPTION
This will rename the former property `distance_previous_node` of `Signal` to `distance_edge`, as to be defined as the distance to `node_a` of `Edge`.
Also, there is a helper method called `distance_previous_node` and **accessible** as a **member**.