### PR TITLE
Make yaramo objects (json) serializable

### DIFF
--- a/yaramo/additional_signal.py
+++ b/yaramo/additional_signal.py
@@ -1,11 +1,15 @@
 
 from enum import Enum
-from typing import List
+from typing import List, Tuple
 from yaramo.base_element import BaseElement
 
 class AdditionalSignal(BaseElement):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+
+    def to_serializable(self) -> Tuple[dict, dict]:
+        base, _ = super().to_serializable()
+        return {**base, 'symbols': [str(symbol) for symbol in self.symbols]}, {}
 
 class AdditionalSignalZs1(AdditionalSignal):
     def __init__(self, symbols: List['AdditionalSignalSymbolZs1'], **kwargs) -> None:

--- a/yaramo/base_element.py
+++ b/yaramo/base_element.py
@@ -17,4 +17,4 @@ class BaseElement(object):
         return self.__dict__, {}
 
     def to_json(self) -> str:
-        return json.dumps(self.to_serializable())
+        return json.dumps(self.to_serializable()[0])

--- a/yaramo/base_element.py
+++ b/yaramo/base_element.py
@@ -1,5 +1,6 @@
-
+from typing import Tuple
 from uuid import uuid4
+import json
 
 
 class BaseElement(object):
@@ -9,3 +10,11 @@ class BaseElement(object):
 
     def __str__(self):
         return self.name or self.uuid
+
+    def to_serializable(self) -> Tuple[dict, dict]:
+        """Return a dictionary of members with references and a dictionary of referenced objects.
+        """
+        return self.__dict__, {}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_serializable())

--- a/yaramo/edge.py
+++ b/yaramo/edge.py
@@ -63,8 +63,7 @@ class Edge(BaseElement):
             'node_a': self.node_a.uuid,
             'node_b': self.node_b.uuid,
             'intermediate_geo_nodes': [geo_node.uuid for geo_node in self.intermediate_geo_nodes],
-            'signals': [signal.uuid for signal in self.signals],
-            'length': self.length
+            'signals': [signal.uuid for signal in self.signals]
         }
         objects = {}
         for geo_node in self.intermediate_geo_nodes:

--- a/yaramo/edge.py
+++ b/yaramo/edge.py
@@ -56,3 +56,21 @@ class Edge(BaseElement):
                 result.append(signal)
         result.sort(key=lambda x: x.distance_edge, reverse=(direction == SignalDirection.GEGEN))
         return result
+
+    def to_serializable(self):
+        base = self.__dict__
+        sub = {
+            'node_a': self.node_a.uuid,
+            'node_b': self.node_b.uuid,
+            'intermediate_geo_nodes': [geo_node.uuid for geo_node in self.intermediate_geo_nodes],
+            'signals': [signal.uuid for signal in self.signals],
+            'length': self.length
+        }
+        items = {}
+        for item in [self.node_a, self.node_b]  + self.intermediate_geo_nodes:
+            _item, _object = item.to_serializable()
+            items = {**items, item.uuid:_item, **_object }
+
+
+        return {**base, **sub}, items
+

--- a/yaramo/edge.py
+++ b/yaramo/edge.py
@@ -58,19 +58,18 @@ class Edge(BaseElement):
         return result
 
     def to_serializable(self):
-        base = self.__dict__
-        sub = {
+        attributes = self.__dict__
+        references = {
             'node_a': self.node_a.uuid,
             'node_b': self.node_b.uuid,
             'intermediate_geo_nodes': [geo_node.uuid for geo_node in self.intermediate_geo_nodes],
             'signals': [signal.uuid for signal in self.signals],
             'length': self.length
         }
-        items = {}
-        for item in [self.node_a, self.node_b]  + self.intermediate_geo_nodes:
-            _item, _object = item.to_serializable()
-            items = {**items, item.uuid:_item, **_object }
+        objects = {}
+        for geo_node in self.intermediate_geo_nodes:
+            geo_node_object, serialized_geo_node = geo_node.to_serializable()
+            objects = {**objects, geo_node.uuid:geo_node_object, **serialized_geo_node}
 
-
-        return {**base, **sub}, items
+        return {**attributes, **references}, objects
 

--- a/yaramo/geo_node.py
+++ b/yaramo/geo_node.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from yaramo.base_element import BaseElement
-from yaramo.geo_point import DbrefGeoPoint, Wgs84GeoPoint
+from yaramo.geo_point import DbrefGeoPoint, GeoPoint, Wgs84GeoPoint
 
 
 class GeoNode(ABC, BaseElement):        
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.geo_point: GeoPoint = None
 
     @abstractmethod
     def get_distance_to_other_geo_node(self, geo_node_b: 'GeoNode'):
@@ -21,12 +22,12 @@ class GeoNode(ABC, BaseElement):
         pass
     
     def to_serializable(self):
-        base = self.__dict__
-        sub = {
+        attributes = self.__dict__
+        references = {
             'geo_point': self.geo_point.uuid,
         }        
-        point_serialized, _ = self.geo_point.to_serializable()
-        return ({**base, **sub}, {self.geo_point.uuid: point_serialized})
+        point_object, point_serialized = self.geo_point.to_serializable()
+        return {**attributes, **references}, {self.geo_point.uuid: point_object, **point_serialized}
 
 
 class Wgs84GeoNode(GeoNode):

--- a/yaramo/geo_node.py
+++ b/yaramo/geo_node.py
@@ -19,6 +19,14 @@ class GeoNode(ABC, BaseElement):
     @abstractmethod
     def to_dbref(self) -> 'DbrefGeoNode':
         pass
+    
+    def to_serializable(self):
+        base = self.__dict__
+        sub = {
+            'geo_point': self.geo_point.uuid,
+        }        
+        point_serialized, _ = self.geo_point.to_serializable()
+        return ({**base, **sub}, {self.geo_point.uuid: point_serialized})
 
 
 class Wgs84GeoNode(GeoNode):

--- a/yaramo/geo_point.py
+++ b/yaramo/geo_point.py
@@ -21,6 +21,9 @@ class GeoPoint(ABC, BaseElement):
     @abstractmethod
     def get_distance_to_other_geo_point(self, geo_point_b: "GeoPoint"):
         pass
+    
+    def to_serializable(self):
+        return self.__dict__, {}
 
     @abstractmethod
     def to_wgs84(self):

--- a/yaramo/node.py
+++ b/yaramo/node.py
@@ -124,3 +124,18 @@ class Node(BaseElement):
             self.connected_on_left, self.connected_on_right = other_a, other_b
         else:
             self.connected_on_left, self.connected_on_right = other_a, other_b
+
+    def to_serializable(self):
+        base = self.__dict__
+        sub = {
+            'connected_on_head': self.connected_on_head.uuid if self.connected_on_head else None,
+            'connected_on_left': self.connected_on_left.uuid if self.connected_on_left else None,
+            'connected_on_right': self.connected_on_right.uuid if self.connected_on_right else None,
+            'connected_nodes': [node.uuid for node in self.connected_nodes],
+            'geo_node': self.geo_node.uuid if self.geo_node else None,
+        }
+        geo_node, serialized_geo_node = {}, {}
+        if self.geo_node:
+            geo_node, serialized_geo_node = self.geo_node.to_serializable()
+            return {**base, **sub}, {**{self.geo_node.uuid:geo_node}, **serialized_geo_node}
+        return {**base, **sub}, {}

--- a/yaramo/node.py
+++ b/yaramo/node.py
@@ -126,16 +126,17 @@ class Node(BaseElement):
             self.connected_on_left, self.connected_on_right = other_a, other_b
 
     def to_serializable(self):
-        base = self.__dict__
-        sub = {
+        attributes = self.__dict__
+        references = {
             'connected_on_head': self.connected_on_head.uuid if self.connected_on_head else None,
             'connected_on_left': self.connected_on_left.uuid if self.connected_on_left else None,
             'connected_on_right': self.connected_on_right.uuid if self.connected_on_right else None,
             'connected_nodes': [node.uuid for node in self.connected_nodes],
             'geo_node': self.geo_node.uuid if self.geo_node else None,
         }
-        geo_node, serialized_geo_node = {}, {}
+        objects = {}
         if self.geo_node:
             geo_node, serialized_geo_node = self.geo_node.to_serializable()
-            return {**base, **sub}, {**{self.geo_node.uuid:geo_node}, **serialized_geo_node}
-        return {**base, **sub}, {}
+            objects = {**objects, self.geo_node.uuid:geo_node, **serialized_geo_node}
+
+        return {**attributes, **references}, objects

--- a/yaramo/route.py
+++ b/yaramo/route.py
@@ -86,33 +86,12 @@ class Route(BaseElement):
         self.maximum_speed = maximum_speed
 
     def to_serializable(self) -> Dict:
-        output_dict = dict()
-        output_dict["start_signal"] = self.start_signal.uuid
-        output_dict["edges"] = []
+        attributes = self.__dict__
+        references = {
+            'maximum_speed':self.maximum_speed,
+            'edges':[edge.uuid for edge in self.edges],
+            'start_signal':self.start_signal.uuid,
+            'end_signal':self.end_signal.uuid if self.end_signal else None,
+        }
 
-        for i, edge in enumerate(self.edges):
-            from_d = 0.0
-            to_d = 0.0
-
-            if i == 0:
-                if self.start_signal.direction == SignalDirection.IN:
-                    from_d = self.start_signal.distance_edge
-                    to_d = edge.length
-                else:
-                    from_d = self.start_signal.distance_edge
-                    to_d = 0.0
-                output_dict["edges"].append({"edge_uuid": edge.uuid, "from": float(from_d), "to": float(to_d)})
-            elif i == len(self.edges) - 1:
-                if self.end_signal.direction == SignalDirection.IN:
-                    from_d = 0.0
-                    to_d = self.end_signal.distance_edge
-                else:
-                    from_d = edge.length
-                    to_d = self.end_signal.distance_edge
-                output_dict["edges"].append({"edge_uuid": edge.uuid, "from": float(from_d), "to": float(to_d)})
-                pass
-            else:
-                output_dict["edges"].append({"edge_uuid": edge.uuid, "from": float(0), "to": float(edge.length)})
-
-        output_dict["end_signal"] = self.end_signal.uuid
-        return output_dict
+        return {**attributes, **references}, {}

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -82,8 +82,8 @@ class Signal(BaseElement):
             return self.edge.length - self.distance_edge
 
     def to_serializable(self) -> Tuple[dict, dict]:
-        base, _ = super().to_serializable()
-        sub = {
+        attributes, _ = super().to_serializable()
+        references = {
             'trip': self.trip,
             'distance_edge': self.distance_edge,
             'classification_number': self.classification_number,
@@ -96,14 +96,11 @@ class Signal(BaseElement):
             'function': str(self.function),
             'kind': str(self.kind),
         }
-        trip_objects = {}
-        if self.trip:
-            trip, trip_object = self.trip.to_serializable()
-            trip_objects = {self.trip.uuid:trip, **trip_object}
-        signal_objects = {}
-        for additional_signal in self.additional_signals:
-            if additional_signal:
-                signal, signal_object = additional_signal.to_serializable()
-                signal_objects = {**signal_objects, **{additional_signal.uuid:signal, **signal_object}}
-        return {**base, **sub}, {**signal_objects, **trip_objects}
+        objects = {}
+        items = [self.trip] + self.additional_signals if self.trip else self.additional_signals
+        for item in items:
+            item_object, serialized_item = item.to_serializable()
+            objects = {**objects, item.uuid:item_object, **serialized_item}
+        
+        return {**attributes, **references}, objects
 

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -84,10 +84,6 @@ class Signal(BaseElement):
     def to_serializable(self) -> Tuple[dict, dict]:
         attributes, _ = super().to_serializable()
         references = {
-            'trip': self.trip,
-            'distance_edge': self.distance_edge,
-            'classification_number': self.classification_number,
-            'control_member_uuid': self.control_member_uuid,
             'edge': self.edge.uuid if self.edge else None,
             'trip':self.trip.uuid if self.trip else None,
             'additional_signals': [signal.uuid for signal in self.additional_signals],

--- a/yaramo/topology.py
+++ b/yaramo/topology.py
@@ -1,9 +1,10 @@
+from yaramo.base_element import BaseElement
 from yaramo.node import Node
 from yaramo.edge import Edge
 from yaramo.route import Route
 from yaramo.signal import Signal
 
-class Topology(object):
+class Topology(BaseElement):
 
     def __init__(self):
         self.nodes: dict[str, Node] = {}
@@ -30,4 +31,29 @@ class Topology(object):
                edge.node_a.uuid == node_b.uuid and edge.node_b.uuid == node_a.uuid:
                 return edge
         return None
+
+    def to_serializable(self):
+        nodes = []
+        edges = []
+        signals = []
+        objects = {}
+        for node in self.nodes.values():
+            reference, serialized = node.to_serializable()
+            nodes.append(reference)
+            objects = {**objects, **serialized}
+        for edge in self.edges.values():
+            reference, serialized = edge.to_serializable()
+            edges.append(reference)
+            objects = {**objects, **serialized}
+        for signal in self.signals.values():
+            reference, serialized = signal.to_serializable()
+            signals.append(reference)
+            objects = {**objects, **serialized}
+
+        return {
+            'nodes': nodes,
+            'edges': edges,
+            'signals': signals,
+            'objects': objects
+        }
 

--- a/yaramo/topology.py
+++ b/yaramo/topology.py
@@ -48,5 +48,5 @@ class Topology(BaseElement):
             'signals': signals,
             'routes':routes,
             'objects': objects
-        }
+        }, {}
 

--- a/yaramo/topology.py
+++ b/yaramo/topology.py
@@ -33,10 +33,10 @@ class Topology(BaseElement):
         return None
 
     def to_serializable(self):
-        nodes, edges, signals = [], [], []
+        nodes, edges, signals, routes = [], [], [], []
         objects = {}
 
-        for items, _list in [(list(self.signals.values()), signals), (list(self.nodes.values()), nodes), (list(self.edges.values()), edges)]:
+        for items, _list in [(list(self.signals.values()), signals), (list(self.nodes.values()), nodes), (list(self.edges.values()), edges), (self.routes, routes)]:
             for item in items:
                 reference, serialized = item.to_serializable()
                 _list.append(reference)
@@ -46,6 +46,7 @@ class Topology(BaseElement):
             'nodes': nodes,
             'edges': edges,
             'signals': signals,
+            'routes':routes,
             'objects': objects
         }
 

--- a/yaramo/topology.py
+++ b/yaramo/topology.py
@@ -33,22 +33,14 @@ class Topology(BaseElement):
         return None
 
     def to_serializable(self):
-        nodes = []
-        edges = []
-        signals = []
+        nodes, edges, signals = [], [], []
         objects = {}
-        for node in self.nodes.values():
-            reference, serialized = node.to_serializable()
-            nodes.append(reference)
-            objects = {**objects, **serialized}
-        for edge in self.edges.values():
-            reference, serialized = edge.to_serializable()
-            edges.append(reference)
-            objects = {**objects, **serialized}
-        for signal in self.signals.values():
-            reference, serialized = signal.to_serializable()
-            signals.append(reference)
-            objects = {**objects, **serialized}
+
+        for items, _list in [(list(self.signals.values()), signals), (list(self.nodes.values()), nodes), (list(self.edges.values()), edges)]:
+            for item in items:
+                reference, serialized = item.to_serializable()
+                _list.append(reference)
+                objects = {**objects, **serialized}
 
         return {
             'nodes': nodes,

--- a/yaramo/trip.py
+++ b/yaramo/trip.py
@@ -1,5 +1,6 @@
 
 import random
+from typing import Tuple
 from yaramo.base_element import BaseElement
 from yaramo.edge import Edge
 
@@ -16,3 +17,6 @@ class Trip(BaseElement):
         for edge in self.edges:
             total_length = total_length + edge.length
         return total_length
+
+    def to_serializable(self) -> Tuple[dict, dict]:
+        return self.__dict__, {}


### PR DESCRIPTION
This will add the `to_serializable()` method to all `yaramo` classes. Said method will attempt to serialize an object's members. In the case of **references objects** it will only include their `uuid`s. A complete serialization of all referenced objects (of a topology) is only secured when calling `to_serializable()` on `Topology`. This is done in order to not serialize objects multiple times, or in case of `Node`s, to avoid circular references. Therefore, **items that are referenced, but not part of a Topology will not be serialized**.