### PR TITLE
replace deprecated pyproj method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "yaramo"
 version = "0.1.0"
 description = "yaramo is a railway model focusing on interoperability between different existing planning formats."
-authors = [""OSM HPI <OSM@HPI>""]
+authors = ["OSM HPI <OSM@HPI>"]
 readme = "README.md"
 packages = [{include = "yaramo"}]
 

--- a/yaramo/geo_point.py
+++ b/yaramo/geo_point.py
@@ -63,9 +63,8 @@ class Wgs84GeoPoint(GeoPoint):
         return self
 
     def to_dbref(self):
-        proj_wgs84 = pyproj.Proj(init="epsg:4326")
-        proj_gk4 = pyproj.Proj(init="epsg:31468")
-        x, y = pyproj.transform(proj_wgs84, proj_gk4, self.y, self.x)
+        transformer = pyproj.Transformer.from_crs("epsg:4326", "epsg:31468")
+        x, y = transformer.transform(self.y, self.x)
         return DbrefGeoPoint(x, y)
 
 


### PR DESCRIPTION
We still use the deprecated `pyproj.transform` method which clutters the output of any program using yaramo with deprecation warnings.