### PR TITLE
Exchange heuristic for anschluss calculation

### DIFF
--- a/yaramo/node.py
+++ b/yaramo/node.py
@@ -117,8 +117,8 @@ class Node(BaseElement):
                 self.connected_on_left, self.connected_on_right = other_a, other_b
             else:
                 self.connected_on_right, self.connected_on_left = other_a, other_b
-        # If they're both above or below that line we make the node that branches further away,
-        # the left or right node depending on the side they're on (left if both above)
+        # If they're both above or below that line, we make the node that branches further away the left or right node,
+        # depending on the side they're on (left if both above)
         else:
             arc_a = get_arc_between_nodes(self.connected_on_head, other_a)
             arc_b = get_arc_between_nodes(self.connected_on_head, other_b)

--- a/yaramo/node.py
+++ b/yaramo/node.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from yaramo.base_element import BaseElement
 from yaramo.geo_node import GeoNode
+from yaramo.geo_point import GeoPoint
 
 
 class NodeConnectionDirection(Enum):
@@ -86,6 +87,9 @@ class Node(BaseElement):
             _c = _node_a.geo_node.get_distance_to_other_geo_node(_node_b.geo_node)
 
             return math.degrees(math.acos((_a * _a + _b * _b - _c * _c) / (2.0 * _a * _b)))
+        
+        def is_above_line_between_points(head_point: GeoPoint, branching_point: GeoPoint, comparison_point: GeoPoint):
+            return ((branching_point.x - head_point.x)*(comparison_point.y - head_point.y) - (branching_point.y - head_point.y)*(comparison_point.x - head_point.x)) > 0
 
         current_max_arc = 361
         other_a: "Node" = None
@@ -103,22 +107,10 @@ class Node(BaseElement):
                         other_b = self.connected_nodes[j]
                         current_max_arc = cur_arc
 
-        other_a_x = other_a.geo_node.geo_point.x
-        other_a_y = other_a.geo_node.geo_point.y
-        other_b_x = other_b.geo_node.geo_point.x
-        other_b_y = other_b.geo_node.geo_point.y
-        self_x = self.geo_node.geo_point.x
-        self_y = self.geo_node.geo_point.y
-        # TODO: Replace this heuristic to determine which node is left and which is right with some suitable algorithm
-        if (
-            (other_a_x < self_x and other_b_x < self_x)
-            or (other_a_x >= self_x and other_b_x >= self_x)
-            or (other_a_y < self_y and other_b_y < self_y)
-            or (other_a_y >= self_y and other_b_y >= self_y)
-        ):
+        if (is_above_line_between_points(self.connected_on_head.geo_node.geo_point, self.geo_node.geo_point, other_a.geo_node.geo_point)):
             self.connected_on_left, self.connected_on_right = other_a, other_b
         else:
-            self.connected_on_left, self.connected_on_right = other_a, other_b
+            self.connected_on_right, self.connected_on_left = other_a, other_b
 
     def to_serializable(self):
         attributes = self.__dict__


### PR DESCRIPTION
The 'Anschlüsse' of a `Node` were calculated by finding the 'head' connected node by comparing all the angles and
then do some comparison based on coordinates. I honestly did not try to understand the heuristic, as it is not documented at all.

What I do now instead, is comparing whether a `GeoPoint` is above or below a line going from head to the current point (above or below in case of a horizontal line, but always on the 'left' of that line).

In case of both nodes being on the same side of said line, we make the node that branches further away the left or right node, depending on the side they're on (left if both above).

**Note**: I have no idea how this ever worked, given that the _else-branch_ had the very same action as the _if-branch_