### PR TITLE
detect geometrically implausible switches

### DIFF
--- a/test/node_test.py
+++ b/test/node_test.py
@@ -1,5 +1,7 @@
 from itertools import product
 
+from pytest import raises
+
 from yaramo.geo_node import Wgs84GeoNode
 from yaramo.node import Node
 
@@ -131,3 +133,17 @@ def test_anschluss():
                 f'{coords_str(switch.connected_on_left)} incorrect'
             assert switch.connected_on_right == right, 'right node ' \
                 f'{coords_str(switch.connected_on_right)} incorrect'
+
+
+def test_implausible_anschluss():
+    """Assert that detection of "Anschluss" (head, left, right) raises
+    an exception on really implausible geographies."""
+    head = create_node(0, 0)   # layout:
+    switch = create_node(2, 2) #      l
+    left = create_node(1, 3)   #       s r
+    right = create_node(3, 2)  #     h
+
+    switch.connected_nodes.extend((head, left, right))
+
+    with raises(Exception) as exception:
+        switch.calc_anschluss_of_all_nodes()

--- a/yaramo/node.py
+++ b/yaramo/node.py
@@ -107,6 +107,8 @@ class Node(BaseElement):
         """Calculates and sets the 'Anschluss' or connection side of
         the connected_nodes based on their geo location."""
 
+        almost_zero = sys.float_info.epsilon
+
         def get_rad_between_nodes(node_a: GeoPoint,
                                   node_b: GeoPoint) -> float:
             """
@@ -125,15 +127,22 @@ class Node(BaseElement):
 
             left_angle_abs = get_rad_between_nodes(self, left)
             left_angle_rel = left_angle_abs - head_angle_abs
-            if cos(left_angle_rel) <= sys.float_info.epsilon:
+            if cos(left_angle_rel) <= almost_zero:
                 # left turn more than (or almost) 90°
                 continue
 
             right_angle_abs = get_rad_between_nodes(self, right)
             right_angle_rel = right_angle_abs- head_angle_abs
-            if cos(right_angle_rel) <= sys.float_info.epsilon:
-                # left turn more than (or almost) 90°
+            if cos(right_angle_rel) <= almost_zero:
+                # right turn more than (or almost) 90°
                 continue
+
+            if cos(left_angle_abs - right_angle_abs) <= almost_zero:
+                # turn from left to right less than (or almost) 90°
+                raise Exception(
+                    f"Node {self} has three connected nodes but "
+                    "geometrically, it does not look like a switch."
+                )
 
             if sin(left_angle_rel) < sin(right_angle_rel):
                 # Left and right mixed up. Although the permutations do


### PR DESCRIPTION
This proposal enhances the calculation of the "Anschlüsse" (head, left, right) by checking for further geometric implausibilities, namely layouts where there is no acute angle.

Needs #46 and #47.