### PR TITLE
Add missing signal states and additional signals

### DIFF
--- a/yaramo/additional_signal.py
+++ b/yaramo/additional_signal.py
@@ -81,14 +81,18 @@ class AdditionalSignalZs2v(AdditionalSignal):
     def __str__(self):
         return "AdditionalSignalZs2v(kind=Zs2v" + ", symbols=" + str(self.symbols) + ")"
 
+class AdditionalSignalZs3Type(Enum):
+    LIGHT_SIGNAL = 0
+    FORM_SIGNAL = 1
 
 class AdditionalSignalZs3(AdditionalSignal):
-    def __init__(self, symbols: List["AdditionalSignalSymbolZs3"], **kwargs) -> None:
+    def __init__(self, symbols: List["AdditionalSignalSymbolZs3"], type: AdditionalSignalZs3Type = AdditionalSignalZs3Type.LIGHT_SIGNAL, **kwargs) -> None:
         super().__init__(**kwargs)
         self.symbols = symbols
+        self.type = type
 
     def __str__(self):
-        return "AdditionalSignalZs3(kind=Zs3" + ", symbols=" + str(self.symbols) + ")"
+        return "AdditionalSignalZs3(kind=Zs3" + ", symbols=" + str(self.symbols) + ", type=" + str(self.type) + ")"
 
     class AdditionalSignalSymbolZs3(Enum):
         OFF = 0
@@ -116,10 +120,23 @@ class AdditionalSignalZs3(AdditionalSignal):
 
 class AdditionalSignalZs3v(AdditionalSignal):
     AdditionalSignalSymbolZs3v = AdditionalSignalZs3.AdditionalSignalSymbolZs3
+    AdditionalSignalZs3vType = AdditionalSignalZs3Type
 
-    def __init__(self, symbols: List["AdditionalSignalSymbolZs3v"], **kwargs) -> None:
+    def __init__(self, symbols: List["AdditionalSignalSymbolZs3v"], type: AdditionalSignalZs3vType = AdditionalSignalZs3vType.LIGHT_SIGNAL, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.symbols = symbols
+        self.type = type
+
+    def __str__(self):
+        return "AdditionalSignalZs3v(kind=Zs3v" + ", symbols=" + str(self.symbols) + ", type=" + str(self.type) + ")"
+
+class AdditionalSignalZs7(AdditionalSignal):
+    def __init__(self, symbols: List["AdditionalSignalSymbolZs7"], **kwargs) -> None:
         super().__init__(**kwargs)
         self.symbols = symbols
 
     def __str__(self):
-        return "AdditionalSignalZs3v(kind=Zs3v" + ", symbols=" + str(self.symbols) + ")"
+        return "AdditionalSignalZs7(kind=Zs7" + ", symbols=" + str(self.symbols) + ")"
+
+    class AdditionalSignalSymbolZs7(Enum):
+        Zs7 = 0

--- a/yaramo/additional_signal.py
+++ b/yaramo/additional_signal.py
@@ -130,6 +130,17 @@ class AdditionalSignalZs3v(AdditionalSignal):
     def __str__(self):
         return "AdditionalSignalZs3v(kind=Zs3v" + ", symbols=" + str(self.symbols) + ", type=" + str(self.type) + ")"
 
+class AdditionalSignalZs6(AdditionalSignal):
+    def __init__(self, symbols: List["AdditionalSignalSymbolZs6"], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.symbols = symbols
+
+    def __str__(self):
+        return "AdditionalSignalZs6(kind=Zs6" + ", symbols=" + str(self.symbols) + ")"
+
+    class AdditionalSignalSymbolZs6(Enum):
+        Zs6 = 0
+
 class AdditionalSignalZs7(AdditionalSignal):
     def __init__(self, symbols: List["AdditionalSignalSymbolZs7"], **kwargs) -> None:
         super().__init__(**kwargs)
@@ -140,3 +151,14 @@ class AdditionalSignalZs7(AdditionalSignal):
 
     class AdditionalSignalSymbolZs7(Enum):
         Zs7 = 0
+
+class AdditionalSignalZs13(AdditionalSignal):
+    def __init__(self, symbols: List["AdditionalSignalSymbolZs13"], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.symbols = symbols
+
+    def __str__(self):
+        return "AdditionalSignalZs13(kind=Zs13" + ", symbols=" + str(self.symbols) + ")"
+
+    class AdditionalSignalSymbolZs13(Enum):
+        Zs13 = 0

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -28,7 +28,7 @@ class SignalFunction(Enum):
     Block_Signal = auto()
     Vorsignal_Vorsignalwiederholer = auto()
     Zwischen_Signal = auto()
-    # Not real signals: signal.kind == SignalKind.FikitivesSignal
+    # Not real signals: signal.kind == SignalKind.FiktivesSignal
     Zug_Ziel_Strecke = auto()
     Rangier_Start_Ziel_ohne_Signal = auto()
     Nicht_Definiert = auto()
@@ -81,11 +81,16 @@ class SignalState(Enum):
     ZS2V = auto()
     ZS3 = auto()
     ZS3V = auto()
+    ZS7 = auto()
     ZLO = auto()
     LF7 = auto()
     RA10 = auto()
     RA12 = auto()
     MS_WS_RT_WS = auto()
+    MS_WS_GE_WS_GE_WS = auto()
+    MS_WS_SW_WS_SW_WS = auto()
+    MS_RT = auto()
+    MS_WS_SW_PT = auto()
     MS_GE_D = auto()
 
     @classmethod
@@ -99,12 +104,20 @@ class SignalState(Enum):
             return SignalState.__members__[state_string_trimmed]
         if state_string == "Mastschild weiß-rot-weiß":
             return SignalState.MS_WS_RT_WS
+        if state_string == "Mastschild weiß-gelb-weiß-gelb-weiß":
+            return SignalState.MS_WS_GE_WS_GE_WS
+        if state_string == "Mastschild weiß-schwarz-weiß-schwarz-weiß":
+            return SignalState.MS_WS_SW_WS_SW_WS
+        if state_string == "Mastschild rot":
+            return SignalState.MS_RT
+        if state_string == "Mastschild weiß mit zwei schwarzen Punkten":
+            return SignalState.MS_WS_SW_PT
         if state_string == "gelbes Dreieck mit Spitze nach unten":
             return SignalState.MS_GE_D
         if state_string == "verkuerzter Abstand des Bremswegs, weißes Zusatzlicht über Signallicht":
             return SignalState.ZLO
         logging.warning(
-            f"The Signal State with the string {state_string} does not exists. Return None instead"
+            f"The Signal State with the string {state_string} does not exist. Returning None instead"
         )
         return None
 
@@ -124,9 +137,10 @@ class Signal(BaseElement):
         function: SignalFunction | str,
         kind: SignalKind | str,
         system: SignalSystem | str = SignalSystem.andere,
-        side_distance: float = None,
-        supported_states: Set[SignalState] = None,
+        side_distance: float | None = None,
+        supported_states: Set[SignalState] | None = None,
         classification_number: str = "60",
+        additional_signals: list[AdditionalSignal] = [],
         **kwargs,
     ):
         """
@@ -147,12 +161,12 @@ class Signal(BaseElement):
         """
 
         super().__init__(**kwargs)
-        self.trip: Trip = None
+        self.trip: Trip | None = None
         self.edge = edge
         self.distance_edge = distance_edge
         self.classification_number = classification_number
         self.control_member_uuid = str(uuid4())
-        self.additional_signals: list[AdditionalSignal] = []
+        self.additional_signals = additional_signals
         self.supported_states: Set[SignalState] = supported_states if supported_states else set()
 
         if isinstance(direction, str):

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -87,10 +87,10 @@ class SignalState(Enum):
     RA10 = auto()
     RA12 = auto()
     MS_WS_RT_WS = auto()
-    MS_WS_GE_WS_GE_WS = auto()
-    MS_WS_SW_WS_SW_WS = auto()
+    MS_WS_GE_WS = auto()
+    MS_WS_SW_WS = auto()
     MS_RT = auto()
-    MS_WS_SW_PT = auto()
+    MS_WS_2SWP = auto()
     MS_GE_D = auto()
 
     @classmethod
@@ -105,13 +105,13 @@ class SignalState(Enum):
         if state_string == "Mastschild weiß-rot-weiß":
             return SignalState.MS_WS_RT_WS
         if state_string == "Mastschild weiß-gelb-weiß-gelb-weiß":
-            return SignalState.MS_WS_GE_WS_GE_WS
+            return SignalState.MS_WS_GE_WS
         if state_string == "Mastschild weiß-schwarz-weiß-schwarz-weiß":
-            return SignalState.MS_WS_SW_WS_SW_WS
+            return SignalState.MS_WS_SW_WS
         if state_string == "Mastschild rot":
             return SignalState.MS_RT
         if state_string == "Mastschild weiß mit zwei schwarzen Punkten":
-            return SignalState.MS_WS_SW_PT
+            return SignalState.MS_WS_2SWP
         if state_string == "gelbes Dreieck mit Spitze nach unten":
             return SignalState.MS_GE_D
         if state_string == "verkuerzter Abstand des Bremswegs, weißes Zusatzlicht über Signallicht":

--- a/yaramo/signal.py
+++ b/yaramo/signal.py
@@ -81,8 +81,12 @@ class SignalState(Enum):
     ZS2V = auto()
     ZS3 = auto()
     ZS3V = auto()
+    ZS6 = auto()
     ZS7 = auto()
+    ZS13 = auto()
     ZLO = auto()
+    ZLU = auto()
+    KL = auto()
     LF7 = auto()
     RA10 = auto()
     RA12 = auto()
@@ -116,6 +120,10 @@ class SignalState(Enum):
             return SignalState.MS_GE_D
         if state_string == "verkuerzter Abstand des Bremswegs, weißes Zusatzlicht über Signallicht":
             return SignalState.ZLO
+        if state_string == "Vorsignalwiederholer, weißes Zusatzlicht unter Signallicht":
+            return SignalState.ZLU
+        if state_string == "ein weißes Licht anstelle der sonst vorgesehenen Signalbilder":
+            return SignalState.KL
         logging.warning(
             f"The Signal State with the string {state_string} does not exist. Returning None instead"
         )


### PR DESCRIPTION
This is a collection of things I noticed while trying to transform a PT1 Signaltabelle 1 to Yaramo. The following changes are included:

- Zs3/Zs3v attribute for signal type (form / light signal) added
- Zs6, Zs7, Zs13 added as additional signals and signal states
- Zusatzlicht unten and Kennlicht added as signal states
- all existing Mastschilder added (I specifically needed "weiß mit zwei schwarzen Punkten")
- additional_signals attribute can be directly set in the constructor of `Signal`
- some typos fixed

The first four points probably also need to be implemented in the importers / exporters. I can try to do this for PlanPro import and export later.

Fixes #60 and fixes #62.